### PR TITLE
Use nightly version of parity

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "Parity"
   ],
   "parity": {
-    "channel": "beta"
+    "channel": "nightly"
   },
   "scripts": {
     "build": "npm run build:inject && npm run build:app && npm run build:electron && npm run build:embed",


### PR DESCRIPTION
The nightly version of parity contains the tobalaba chain spec.